### PR TITLE
feat: wire shell tools into registry and system prompt

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -40,6 +40,7 @@ export interface CashClawConfig {
   learningEnabled: boolean;
   studyIntervalMs: number;
   agentCashEnabled: boolean;
+  shellEnabled: boolean;
 }
 
 const CONFIG_DIR = path.join(os.homedir(), ".cashclaw");
@@ -56,6 +57,7 @@ const DEFAULT_CONFIG: Omit<CashClawConfig, "agentId" | "llm"> = {
   learningEnabled: true,
   studyIntervalMs: 1_800_000, // 30 minutes
   agentCashEnabled: false,
+  shellEnabled: false,
 };
 
 export function loadConfig(): CashClawConfig | null {

--- a/src/loop/prompt.ts
+++ b/src/loop/prompt.ts
@@ -89,6 +89,11 @@ You receive tasks from clients and use tools to take actions. You MUST use tools
     prompt += buildAgentCashCatalog();
   }
 
+  // Shell and filesystem capabilities
+  if (config.shellEnabled) {
+    prompt += buildShellCapabilities();
+  }
+
   return prompt;
 }
 
@@ -149,4 +154,45 @@ You have access to 100+ paid APIs via the \`agentcash_fetch\` tool. Each call co
 | Endpoint | Method | Price | Description |
 |----------|--------|-------|-------------|
 | \`https://stableemail.dev/send\` | POST | $0.01 | Send email. Body: \`{ "to": "...", "subject": "...", "body": "..." }\` |`;
+}
+
+function buildShellCapabilities(): string {
+  return `
+
+## Shell & Filesystem Tools
+
+You have direct access to the local system to execute code and manage files.
+
+### run_command
+Execute shell commands (node, npm, npx, python, git, etc.).
+- \`command\`: executable name (node, npm, npx, python3, git, bash, tsc, bun)
+- \`args\`: array of arguments
+- \`cwd\`: working directory (optional)
+- \`timeout\`: ms, default 30000, max 120000
+Returns: \`{ stdout, stderr, exitCode }\`
+
+### read_file
+Read a file's contents.
+- \`path\`: file path (must be within cwd or /tmp)
+- \`encoding\`: "utf8" (default) or "base64"
+Max size: 1 MB.
+
+### write_file
+Write content to a file (auto-creates parent directories).
+- \`path\`: file path
+- \`content\`: string content
+- \`mode\`: "overwrite" (default) or "append"
+
+### list_directory
+List files in a directory.
+- \`path\`: directory path
+- \`recursive\`: recurse subdirectories (max depth 3)
+- \`pattern\`: filter by extension (e.g. "*.ts")
+
+### Usage guidelines
+- Use a temp working directory like /tmp/<task-id>/ for task work
+- Install dependencies with: \`run_command("npm", ["install"], { cwd: "/tmp/task" })\`
+- Run tests with: \`run_command("npm", ["test"], { cwd: "/tmp/task" })\`
+- Always read files before modifying them
+- Clean up temp files when done`;
 }

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -17,6 +17,8 @@ import {
   logActivity,
 } from "./utility.js";
 import { agentcashFetch, agentcashBalance } from "./agentcash.js";
+import { runCommand } from "./shell.js";
+import { readFile, writeFile, listDirectory } from "./filesystem.js";
 
 const BASE_TOOLS: Tool[] = [
   readTask,
@@ -37,15 +39,17 @@ const AGENTCASH_TOOLS: Tool[] = [
   agentcashBalance,
 ];
 
+const SHELL_TOOLS: Tool[] = [runCommand, readFile, writeFile, listDirectory];
+
 // Memoize by config reference to avoid rebuilding on every tool call
 let cachedConfig: CashClawConfig | null = null;
 let cachedToolMap: Map<string, Tool> | null = null;
 
 function buildToolMap(config: CashClawConfig): Map<string, Tool> {
   if (cachedConfig === config && cachedToolMap) return cachedToolMap;
-  const tools = config.agentCashEnabled
-    ? [...BASE_TOOLS, ...AGENTCASH_TOOLS]
-    : BASE_TOOLS;
+  let tools = [...BASE_TOOLS];
+  if (config.agentCashEnabled) tools = [...tools, ...AGENTCASH_TOOLS];
+  if (config.shellEnabled) tools = [...tools, ...SHELL_TOOLS];
   cachedToolMap = new Map(tools.map((t) => [t.definition.name, t]));
   cachedConfig = config;
   return cachedToolMap;


### PR DESCRIPTION
## Summary

- Add `shellEnabled: boolean` field to `CashClawConfig` interface and defaults (off by default)
- Register `SHELL_TOOLS` (`run_command`, `read_file`, `write_file`, `list_directory`) conditionally in `buildToolMap` when `shellEnabled` is true
- Inject shell and filesystem capabilities section into the system prompt via `buildShellCapabilities()` when `shellEnabled` is true

## Test plan

- [x] `npm test` — all 7 tests pass
- [ ] TypeScript errors for missing `./shell.js` / `./filesystem.js` modules are expected and will resolve when parallel PRs are merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)