### PR TITLE
feat: core LLM router with OpenRouter provider (Unit 3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
-  "name": "cashclaw",
+  "name": "cashclaw-agent",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "cashclaw",
+      "name": "cashclaw-agent",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "minisearch": "^7.2.0",
+        "openai": "^6.32.0",
         "viem": "^2.23.0",
         "ws": "^8.19.0"
       },
@@ -2690,6 +2691,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.32.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.32.0.tgz",
+      "integrity": "sha512-j3k+BjydAf8yQlcOI7WUQMQTbbF5GEIMAE2iZYCOzwwB3S2pCheaWYp+XZRNAch4jWVc52PMDGRRjutao3lLCg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/ox": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "minisearch": "^7.2.0",
+    "openai": "^6.32.0",
     "viem": "^2.23.0",
     "ws": "^8.19.0"
   },

--- a/src/core/llm/providers/openrouter.ts
+++ b/src/core/llm/providers/openrouter.ts
@@ -1,0 +1,41 @@
+import OpenAI from "openai";
+import type { LLMClient, LLMMessage, LLMResponse } from "../types.js";
+
+export interface OpenRouterOptions {
+  apiKey: string;
+  model: string;
+}
+
+export function createOpenRouterClient(opts: OpenRouterOptions): LLMClient {
+  const client = new OpenAI({
+    apiKey: opts.apiKey,
+    baseURL: "https://openrouter.ai/api/v1",
+    defaultHeaders: {
+      "HTTP-Referer": "https://cashclaw.dev",
+      "X-Title": "CashClaw",
+    },
+  });
+
+  return {
+    async chat(messages: LLMMessage[]): Promise<LLMResponse> {
+      const res = await client.chat.completions.create({
+        model: opts.model,
+        messages: messages.map((m) => ({
+          role: m.role,
+          content: m.content,
+        })),
+      });
+
+      const choice = res.choices[0];
+      return {
+        text: choice?.message?.content ?? "",
+        usage: res.usage
+          ? {
+              promptTokens: res.usage.prompt_tokens,
+              completionTokens: res.usage.completion_tokens,
+            }
+          : undefined,
+      };
+    },
+  };
+}

--- a/src/core/llm/router.ts
+++ b/src/core/llm/router.ts
@@ -1,0 +1,42 @@
+import type { LLMClient } from "./types.js";
+import { createOpenRouterClient } from "./providers/openrouter.js";
+
+export interface LLMRouterConfig {
+  provider: string;
+  api_key: string;
+  fast_model: string;
+  strong_model: string;
+}
+
+export class LLMRouter {
+  private readonly config: LLMRouterConfig;
+  private fastClient: LLMClient | undefined;
+  private strongClient: LLMClient | undefined;
+
+  constructor(config: LLMRouterConfig) {
+    this.config = config;
+  }
+
+  fast(): LLMClient {
+    if (!this.fastClient) {
+      this.fastClient = this.createClient(this.config.fast_model);
+    }
+    return this.fastClient;
+  }
+
+  strong(): LLMClient {
+    if (!this.strongClient) {
+      this.strongClient = this.createClient(this.config.strong_model);
+    }
+    return this.strongClient;
+  }
+
+  private createClient(model: string): LLMClient {
+    switch (this.config.provider) {
+      case "openrouter":
+        return createOpenRouterClient({ apiKey: this.config.api_key, model });
+      default:
+        throw new Error(`Unknown LLM provider: ${this.config.provider}`);
+    }
+  }
+}

--- a/src/core/llm/types.ts
+++ b/src/core/llm/types.ts
@@ -1,0 +1,22 @@
+/** A single message in a chat conversation. */
+export interface LLMMessage {
+  role: "system" | "user" | "assistant";
+  content: string;
+}
+
+/** A chunk emitted during streaming. */
+export interface LLMStreamChunk {
+  delta: string;
+  done: boolean;
+}
+
+/** A complete (non-streaming) LLM response. */
+export interface LLMResponse {
+  text: string;
+  usage?: { promptTokens: number; completionTokens: number };
+}
+
+/** Minimal client interface used by the router. */
+export interface LLMClient {
+  chat(messages: LLMMessage[]): Promise<LLMResponse>;
+}

--- a/test/core/llm.test.ts
+++ b/test/core/llm.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest'
+import { LLMRouter } from '../../src/core/llm/router'
+
+describe('LLMRouter', () => {
+  it('creates router and returns fast/strong clients', () => {
+    const router = new LLMRouter({
+      provider: 'openrouter',
+      api_key: 'test-key',
+      fast_model: 'test/fast',
+      strong_model: 'test/strong'
+    })
+    expect(router.fast()).toBeDefined()
+    expect(router.strong()).toBeDefined()
+  })
+})


### PR DESCRIPTION
## Summary
- Add `src/core/llm/` module with types (`LLMMessage`, `LLMStreamChunk`, `LLMResponse`, `LLMClient`), a router (`LLMRouter`) with lazy fast/strong tier selection, and an OpenRouter provider backed by the OpenAI SDK
- Router takes a plain config object (`{ provider, api_key, fast_model, strong_model }`) with no dependency on telegram/config
- All imports use `.js` ESM extensions

## Test plan
- [x] `npx vitest run test/core/llm.test.ts` passes (creates router, verifies fast/strong clients are returned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)