### PR TITLE
feat: core tool system — types, registry, shell, files, http

### DIFF
--- a/src/core/tools/files.ts
+++ b/src/core/tools/files.ts
@@ -1,0 +1,62 @@
+import { readFile, writeFile, readdir } from "node:fs/promises"
+import type { Tool, ToolResult } from "./types.js"
+
+export class FilesTool implements Tool {
+  name = "files"
+  description = "Read, write, or list files"
+  parameters = [
+    { name: "action", type: "string", description: "Action to perform: read, write, or list", required: true },
+    { name: "path", type: "string", description: "File or directory path", required: true },
+    { name: "content", type: "string", description: "Content to write (required for write action)" },
+  ]
+
+  async execute(params: Record<string, unknown>): Promise<ToolResult> {
+    const action = params.action as string | undefined
+    const path = params.path as string | undefined
+
+    if (!action || !path) {
+      return { success: false, output: "", error: "Missing required parameters: action and path" }
+    }
+
+    switch (action) {
+      case "read":
+        return this.read(path)
+      case "write":
+        return this.write(path, params.content as string | undefined)
+      case "list":
+        return this.list(path)
+      default:
+        return { success: false, output: "", error: `Unknown action: ${action}. Use read, write, or list.` }
+    }
+  }
+
+  private async read(path: string): Promise<ToolResult> {
+    try {
+      const data = await readFile(path, "utf-8")
+      return { success: true, output: data }
+    } catch (err) {
+      return { success: false, output: "", error: (err as Error).message }
+    }
+  }
+
+  private async write(path: string, content: string | undefined): Promise<ToolResult> {
+    if (content === undefined) {
+      return { success: false, output: "", error: "Missing required parameter: content (for write action)" }
+    }
+    try {
+      await writeFile(path, content, "utf-8")
+      return { success: true, output: `Written to ${path}` }
+    } catch (err) {
+      return { success: false, output: "", error: (err as Error).message }
+    }
+  }
+
+  private async list(path: string): Promise<ToolResult> {
+    try {
+      const entries = await readdir(path)
+      return { success: true, output: entries.join("\n") }
+    } catch (err) {
+      return { success: false, output: "", error: (err as Error).message }
+    }
+  }
+}

--- a/src/core/tools/http.ts
+++ b/src/core/tools/http.ts
@@ -1,0 +1,55 @@
+import type { Tool, ToolResult } from "./types.js"
+
+export class HttpTool implements Tool {
+  name = "http"
+  description = "Make HTTP requests"
+  parameters = [
+    { name: "url", type: "string", description: "The URL to request", required: true },
+    { name: "method", type: "string", description: "HTTP method: GET, POST, PUT, or DELETE" },
+    { name: "body", type: "string", description: "Request body (for POST/PUT)" },
+    { name: "headers", type: "string", description: "JSON-encoded headers object" },
+  ]
+
+  async execute(params: Record<string, unknown>): Promise<ToolResult> {
+    const url = params.url as string | undefined
+    if (!url) {
+      return { success: false, output: "", error: "Missing required parameter: url" }
+    }
+
+    const method = ((params.method as string) || "GET").toUpperCase()
+    const body = params.body as string | undefined
+
+    let headers: Record<string, string> | undefined
+    if (params.headers) {
+      try {
+        headers = typeof params.headers === "string" ? JSON.parse(params.headers) : (params.headers as Record<string, string>)
+      } catch {
+        return { success: false, output: "", error: "Invalid headers: must be a JSON-encoded object" }
+      }
+    }
+
+    try {
+      const controller = new AbortController()
+      const timer = setTimeout(() => controller.abort(), 30_000)
+
+      const response = await fetch(url, {
+        method,
+        headers,
+        body,
+        signal: controller.signal,
+      })
+
+      clearTimeout(timer)
+
+      const text = await response.text()
+
+      if (!response.ok) {
+        return { success: false, output: text, error: `HTTP ${response.status} ${response.statusText}` }
+      }
+
+      return { success: true, output: text }
+    } catch (err) {
+      return { success: false, output: "", error: (err as Error).message }
+    }
+  }
+}

--- a/src/core/tools/registry.ts
+++ b/src/core/tools/registry.ts
@@ -1,0 +1,25 @@
+import type { Tool, ToolParam } from "./types.js"
+
+export class ToolRegistry {
+  private tools = new Map<string, Tool>()
+
+  register(tool: Tool): void {
+    this.tools.set(tool.name, tool)
+  }
+
+  get(name: string): Tool | undefined {
+    return this.tools.get(name)
+  }
+
+  list(): Tool[] {
+    return [...this.tools.values()]
+  }
+
+  getToolDefinitions(): Array<{ name: string; description: string; parameters: ToolParam[] }> {
+    return this.list().map((t) => ({
+      name: t.name,
+      description: t.description,
+      parameters: t.parameters,
+    }))
+  }
+}

--- a/src/core/tools/shell.ts
+++ b/src/core/tools/shell.ts
@@ -1,0 +1,39 @@
+import { exec } from "node:child_process"
+import type { Tool, ToolResult } from "./types.js"
+
+const BLACKLIST_PATTERNS = ["rm -rf /", "mkfs", "dd if=", "format"]
+
+function isDangerous(command: string): boolean {
+  const lower = command.toLowerCase()
+  return BLACKLIST_PATTERNS.some((p) => lower.includes(p))
+}
+
+export class ShellTool implements Tool {
+  name = "shell"
+  description = "Execute a shell command"
+  parameters = [
+    { name: "command", type: "string", description: "The shell command to execute", required: true },
+  ]
+  requiresConfirmation = true
+
+  async execute(params: Record<string, unknown>): Promise<ToolResult> {
+    const command = params.command
+    if (typeof command !== "string" || !command.trim()) {
+      return { success: false, output: "", error: "Missing required parameter: command" }
+    }
+
+    if (isDangerous(command)) {
+      return { success: false, output: "", error: "Command blocked: matches a dangerous pattern" }
+    }
+
+    return new Promise((resolve) => {
+      exec(command, { timeout: 30_000 }, (err, stdout, stderr) => {
+        if (err) {
+          resolve({ success: false, output: stderr || stdout || "", error: err.message })
+        } else {
+          resolve({ success: true, output: stdout, error: stderr || undefined })
+        }
+      })
+    })
+  }
+}

--- a/src/core/tools/types.ts
+++ b/src/core/tools/types.ts
@@ -1,0 +1,20 @@
+export interface ToolParam {
+  name: string
+  type: string // 'string' | 'number' | 'boolean'
+  description: string
+  required?: boolean
+}
+
+export interface ToolResult {
+  success: boolean
+  output: string
+  error?: string
+}
+
+export interface Tool {
+  name: string
+  description: string
+  parameters: ToolParam[]
+  requiresConfirmation?: boolean
+  execute(params: Record<string, unknown>): Promise<ToolResult>
+}

--- a/test/core/tools/shell.test.ts
+++ b/test/core/tools/shell.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest"
+import { ShellTool } from "../../../src/core/tools/shell.js"
+
+describe("ShellTool", () => {
+  const tool = new ShellTool()
+
+  it("executes command", async () => {
+    const result = await tool.execute({ command: "echo hello" })
+    expect(result.success).toBe(true)
+    expect(result.output.trim()).toBe("hello")
+  })
+
+  it("returns error for bad command", async () => {
+    const result = await tool.execute({ command: "nonexistent_xyz_cmd" })
+    expect(result.success).toBe(false)
+    expect(result.error).toBeDefined()
+  })
+
+  it("blocks dangerous commands", async () => {
+    const result = await tool.execute({ command: "rm -rf /" })
+    expect(result.success).toBe(false)
+    expect(result.error).toContain("blocked")
+  })
+
+  it("returns error for missing command", async () => {
+    const result = await tool.execute({})
+    expect(result.success).toBe(false)
+    expect(result.error).toContain("Missing")
+  })
+})


### PR DESCRIPTION
## Summary
- Adds the new `src/core/tools/` module with `Tool`, `ToolParam`, `ToolResult` interfaces and `ToolRegistry` class
- Implements three built-in tools: `ShellTool` (exec with blacklist), `FilesTool` (read/write/list), `HttpTool` (fetch with timeout)
- Adds unit tests for ShellTool (command execution, error handling, dangerous command blocking)

This is Unit 6 of the agent restructuring: establishing the core tool abstraction layer that the agentic loop will use.

## Test plan
- [x] `npx vitest run test/core/tools/` — 4 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)