### PR TITLE
feat: add browser tool with Playwright (Unit 7)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
-  "name": "cashclaw",
+  "name": "cashclaw-agent",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "cashclaw",
+      "name": "cashclaw-agent",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "minisearch": "^7.2.0",
+        "playwright": "^1.58.2",
         "viem": "^2.23.0",
         "ws": "^8.19.0"
       },
@@ -2779,6 +2780,50 @@
         "confbox": "^0.1.8",
         "mlly": "^1.7.4",
         "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "minisearch": "^7.2.0",
+    "playwright": "^1.58.2",
     "viem": "^2.23.0",
     "ws": "^8.19.0"
   },

--- a/src/core/tools/browser.ts
+++ b/src/core/tools/browser.ts
@@ -1,0 +1,146 @@
+import type { Browser, BrowserContext, Page } from "playwright";
+import type { Tool, ToolParam, ToolResult } from "./types.js";
+
+type BrowserAction = "get_text" | "screenshot" | "search" | "click" | "fill" | "evaluate";
+
+const TIMEOUT = 30_000;
+
+const PARAMETERS: ToolParam[] = [
+  { name: "action", type: "string", description: "Action to perform: get_text, screenshot, search, click, fill, evaluate", required: true },
+  { name: "url", type: "string", description: "URL to navigate to" },
+  { name: "selector", type: "string", description: "CSS selector for click/fill actions" },
+  { name: "value", type: "string", description: "Value for fill/search actions" },
+  { name: "script", type: "string", description: "JavaScript to evaluate on the page" },
+];
+
+export class BrowserTool implements Tool {
+  readonly name = "browser";
+  readonly description = "Browse the web — open pages, search, take screenshots";
+  readonly parameters = PARAMETERS;
+
+  private browser: Browser | null = null;
+  private context: BrowserContext | null = null;
+  private page: Page | null = null;
+
+  async execute(params: Record<string, unknown>): Promise<ToolResult> {
+    const action = params.action as BrowserAction | undefined;
+    if (!action) {
+      return { success: false, output: "", error: "Missing required parameter: action" };
+    }
+
+    try {
+      const page = await this.getPage();
+
+      switch (action) {
+        case "get_text":
+          return await this.getText(page, params.url as string | undefined);
+        case "screenshot":
+          return await this.screenshot(page, params.url as string | undefined);
+        case "search":
+          return await this.search(page, params.value as string | undefined);
+        case "click":
+          return await this.click(page, params.selector as string | undefined);
+        case "fill":
+          return await this.fill(page, params.selector as string | undefined, params.value as string | undefined);
+        case "evaluate":
+          return await this.evaluateScript(page, params.script as string | undefined);
+        default:
+          return { success: false, output: "", error: `Unknown action: ${action}` };
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { success: false, output: "", error: message };
+    }
+  }
+
+  async dispose(): Promise<void> {
+    const browser = this.browser;
+    this.page = null;
+    this.context = null;
+    this.browser = null;
+    if (browser) {
+      await browser.close();
+    }
+  }
+
+  // ---- private ----------------------------------------------------------
+
+  private async getPage(): Promise<Page> {
+    if (this.page) return this.page;
+
+    const { chromium } = await import("playwright");
+
+    try {
+      this.browser = await chromium.launch({ headless: true });
+    } catch {
+      // Chromium not installed — attempt auto-install
+      const { execSync } = await import("child_process");
+      execSync("npx playwright install chromium", { stdio: "pipe", timeout: 120_000 });
+      this.browser = await chromium.launch({ headless: true });
+    }
+
+    this.context = await this.browser.newContext();
+    this.page = await this.context.newPage();
+    this.page.setDefaultTimeout(TIMEOUT);
+    return this.page;
+  }
+
+  private async getText(page: Page, url: string | undefined): Promise<ToolResult> {
+    if (!url) return { success: false, output: "", error: "Missing required parameter: url" };
+    await page.goto(url, { timeout: TIMEOUT, waitUntil: "domcontentloaded" });
+    const text = await page.textContent("body") ?? "";
+    return { success: true, output: text.replace(/\s+/g, " ").trim() };
+  }
+
+  private async screenshot(page: Page, url: string | undefined): Promise<ToolResult> {
+    if (!url) return { success: false, output: "", error: "Missing required parameter: url" };
+    await page.goto(url, { timeout: TIMEOUT, waitUntil: "domcontentloaded" });
+    const buffer = await page.screenshot({ fullPage: true });
+    return { success: true, output: buffer.toString("base64") };
+  }
+
+  private async search(page: Page, query: string | undefined): Promise<ToolResult> {
+    if (!query) return { success: false, output: "", error: "Missing required parameter: value (search query)" };
+    const encoded = encodeURIComponent(query);
+    await page.goto(`https://www.google.com/search?q=${encoded}`, { timeout: TIMEOUT, waitUntil: "domcontentloaded" });
+
+    const results = await page.evaluate(() => {
+      const items: { title: string; url: string; snippet: string }[] = [];
+      document.querySelectorAll("div.g").forEach((el) => {
+        const anchor = el.querySelector("a");
+        const title = el.querySelector("h3")?.textContent ?? "";
+        const snippet = el.querySelector("[data-sncf]")?.textContent
+          ?? el.querySelector(".VwiC3b")?.textContent
+          ?? "";
+        if (anchor?.href && title) {
+          items.push({ title, url: anchor.href, snippet });
+        }
+      });
+      return items.slice(0, 10);
+    });
+
+    const formatted = results.map((r, i) => `${i + 1}. ${r.title}\n   ${r.url}\n   ${r.snippet}`).join("\n\n");
+    return { success: true, output: formatted || "No results found" };
+  }
+
+  private async click(page: Page, selector: string | undefined): Promise<ToolResult> {
+    if (!selector) return { success: false, output: "", error: "Missing required parameter: selector" };
+    await page.click(selector, { timeout: TIMEOUT });
+    return { success: true, output: `Clicked: ${selector}` };
+  }
+
+  private async fill(page: Page, selector: string | undefined, value: string | undefined): Promise<ToolResult> {
+    if (!selector) return { success: false, output: "", error: "Missing required parameter: selector" };
+    if (value === undefined) return { success: false, output: "", error: "Missing required parameter: value" };
+    await page.fill(selector, value, { timeout: TIMEOUT });
+    return { success: true, output: `Filled ${selector} with value` };
+  }
+
+  private async evaluateScript(page: Page, script: string | undefined): Promise<ToolResult> {
+    if (!script) return { success: false, output: "", error: "Missing required parameter: script" };
+    const result = await page.evaluate(script);
+    if (result === undefined || result === null) return { success: true, output: "" };
+    const output = typeof result === "string" ? result : JSON.stringify(result, null, 2);
+    return { success: true, output };
+  }
+}

--- a/src/core/tools/types.ts
+++ b/src/core/tools/types.ts
@@ -1,0 +1,20 @@
+export interface ToolParam {
+  name: string;
+  type: string;
+  description: string;
+  required?: boolean;
+}
+
+export interface ToolResult {
+  success: boolean;
+  output: string;
+  error?: string;
+}
+
+export interface Tool {
+  name: string;
+  description: string;
+  parameters: ToolParam[];
+  requiresConfirmation?: boolean;
+  execute(params: Record<string, unknown>): Promise<ToolResult>;
+}

--- a/test/core/tools/browser.test.ts
+++ b/test/core/tools/browser.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { BrowserTool } from "../../../src/core/tools/browser.js";
+
+describe("BrowserTool", () => {
+  it("has correct name and parameters", () => {
+    const tool = new BrowserTool();
+    expect(tool.name).toBe("browser");
+    expect(tool.parameters.length).toBeGreaterThan(0);
+  });
+
+  it("has correct description", () => {
+    const tool = new BrowserTool();
+    expect(tool.description).toContain("Browse the web");
+  });
+
+  it("returns error for missing action", async () => {
+    const tool = new BrowserTool();
+    const result = await tool.execute({});
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("action");
+  });
+
+  // NOTE: Skip actual browser tests in CI — they need Chromium installed
+  // The test below is for local validation only
+  it.skip("gets text from example.com", async () => {
+    const tool = new BrowserTool();
+    try {
+      const result = await tool.execute({ action: "get_text", url: "https://example.com" });
+      expect(result.success).toBe(true);
+      expect(result.output).toContain("Example Domain");
+    } finally {
+      await tool.dispose();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add shared `Tool`, `ToolParam`, and `ToolResult` types in `src/core/tools/types.ts` for the restructured agent architecture
- Implement `BrowserTool` in `src/core/tools/browser.ts` wrapping Playwright chromium with lazy initialization and auto-install
- Supports 6 actions: `get_text`, `screenshot`, `search`, `click`, `fill`, `evaluate` with 30s timeout per action
- Add unit tests covering structural validation and missing-parameter error handling

## Test plan
- [x] Structural tests pass (`npx vitest run test/core/tools/browser.test.ts` — 3 passed, 1 skipped)
- [ ] E2E browser tests skipped (require Chromium install)

🤖 Generated with [Claude Code](https://claude.com/claude-code)