### PR TITLE
feat: browser channel, plugin system, and shared core types

### DIFF
--- a/src/channels/browser/index.ts
+++ b/src/channels/browser/index.ts
@@ -1,0 +1,51 @@
+import type { WebSocket, WebSocketServer } from "ws";
+import type { IncomingMessage, OutgoingMessage } from "../../core/types.js";
+import type { Channel } from "../types.js";
+
+export class BrowserChannel implements Channel {
+  name = "browser";
+  requiredConfig: string[] = [];
+
+  private wss: WebSocketServer | null = null;
+  private handler: ((msg: IncomingMessage) => Promise<OutgoingMessage>) | null = null;
+  private clients = new Set<WebSocket>();
+
+  async start(_config: Record<string, string>): Promise<void> {
+    // WSS is attached to the HTTP server externally via attachWSS()
+  }
+
+  attachWSS(wss: WebSocketServer): void {
+    this.wss = wss;
+    wss.on("connection", (ws: WebSocket) => {
+      this.clients.add(ws);
+      ws.on("message", async (data: Buffer | string) => {
+        const msg: IncomingMessage = {
+          channelName: "browser",
+          userId: "owner",
+          text: data.toString(),
+          timestamp: Date.now(),
+        };
+        if (this.handler) {
+          const response = await this.handler(msg);
+          ws.send(JSON.stringify(response));
+        }
+      });
+      ws.on("close", () => this.clients.delete(ws));
+    });
+  }
+
+  async send(_userId: string, message: OutgoingMessage): Promise<void> {
+    const data = JSON.stringify(message);
+    for (const ws of this.clients) {
+      ws.send(data);
+    }
+  }
+
+  onMessage(handler: (msg: IncomingMessage) => Promise<OutgoingMessage>): void {
+    this.handler = handler;
+  }
+
+  async stop(): Promise<void> {
+    this.wss?.close();
+  }
+}

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -1,0 +1,10 @@
+import type { IncomingMessage, OutgoingMessage } from "../core/types.js";
+
+export interface Channel {
+  name: string;
+  requiredConfig: string[];
+  start(config: Record<string, string>): Promise<void>;
+  stop(): Promise<void>;
+  send(userId: string, message: OutgoingMessage): Promise<void>;
+  onMessage(handler: (msg: IncomingMessage) => Promise<OutgoingMessage>): void;
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,0 +1,12 @@
+export interface IncomingMessage {
+  channelName: string;
+  userId: string;
+  text: string;
+  timestamp: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface OutgoingMessage {
+  text: string;
+  mode?: "text" | "voice" | "video" | "selfie";
+}

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -1,0 +1,34 @@
+import type { Plugin } from "./types.js";
+
+const plugins = new Map<string, Plugin>();
+
+export function registerPlugin(plugin: Plugin): void {
+  if (plugins.has(plugin.name)) {
+    throw new Error(`Plugin "${plugin.name}" is already registered`);
+  }
+  plugins.set(plugin.name, plugin);
+}
+
+export function getPlugin(name: string): Plugin | undefined {
+  return plugins.get(name);
+}
+
+export function getAllPlugins(): Plugin[] {
+  return Array.from(plugins.values());
+}
+
+export async function activateAll(): Promise<void> {
+  for (const plugin of plugins.values()) {
+    await plugin.activate();
+  }
+}
+
+export async function deactivateAll(): Promise<void> {
+  for (const plugin of plugins.values()) {
+    await plugin.deactivate();
+  }
+}
+
+export function clearPlugins(): void {
+  plugins.clear();
+}

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1,0 +1,7 @@
+export interface Plugin {
+  name: string;
+  version: string;
+  description: string;
+  activate(): Promise<void>;
+  deactivate(): Promise<void>;
+}

--- a/test/channels/browser.test.ts
+++ b/test/channels/browser.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { BrowserChannel } from "../../src/channels/browser/index.js";
+
+describe("BrowserChannel", () => {
+  it("has correct name and empty config", () => {
+    const ch = new BrowserChannel();
+    expect(ch.name).toBe("browser");
+    expect(ch.requiredConfig).toEqual([]);
+  });
+
+  it("registers a message handler via onMessage", () => {
+    const ch = new BrowserChannel();
+    const handler = async () => ({ text: "hello" });
+    ch.onMessage(handler);
+    // No error thrown — handler accepted
+  });
+
+  it("start and stop resolve without error", async () => {
+    const ch = new BrowserChannel();
+    await ch.start({});
+    await ch.stop();
+  });
+});


### PR DESCRIPTION
## Summary
- Add shared core types (`IncomingMessage`, `OutgoingMessage`) in `src/core/types.ts`
- Add `Channel` interface in `src/channels/types.ts` for multi-channel support
- Add `BrowserChannel` (`src/channels/browser/index.ts`) — WebSocket-based chat channel that accepts an externally attached `WebSocketServer`
- Add plugin system (`src/plugins/types.ts`, `src/plugins/registry.ts`) with register, activate, deactivate lifecycle
- Add unit tests for `BrowserChannel`

## Test plan
- [x] `npx vitest run test/channels/` — 3 tests pass (name, config, start/stop lifecycle)
- [ ] Integration with actual WebSocket server (deferred to e2e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)