### PR TITLE
feat: add core tools — memory, npm-install, scheduler, self-config, ssh

### DIFF
--- a/src/core/tools/memory.ts
+++ b/src/core/tools/memory.ts
@@ -1,0 +1,131 @@
+import crypto from "node:crypto";
+import type { Tool, ToolResult } from "./types.js";
+import {
+  loadKnowledge,
+  storeKnowledge,
+  deleteKnowledge,
+  type KnowledgeEntry,
+} from "../../memory/knowledge.js";
+import { searchMemory } from "../../memory/search.js";
+
+function requireString(
+  params: Record<string, unknown>,
+  key: string,
+): string {
+  const val = params[key];
+  if (typeof val !== "string" || !val.trim()) {
+    throw new Error(`Missing required parameter: ${key}`);
+  }
+  return val.trim();
+}
+
+function handleSearch(params: Record<string, unknown>): ToolResult {
+  const query = requireString(params, "query");
+  const limit =
+    typeof params.limit === "number" && params.limit > 0
+      ? params.limit
+      : 5;
+
+  const hits = searchMemory(query, limit);
+
+  if (hits.length === 0) {
+    return { success: true, output: "No relevant memories found." };
+  }
+
+  const summary = hits
+    .map((h, i) => `${i + 1}. [${h.type}] ${h.text.slice(0, 300)}`)
+    .join("\n\n");
+
+  return { success: true, output: summary };
+}
+
+function handleSave(params: Record<string, unknown>): ToolResult {
+  const insight = requireString(params, "content");
+  const specialty =
+    typeof params.specialty === "string" && params.specialty.trim()
+      ? params.specialty.trim()
+      : "general";
+  const topic =
+    typeof params.topic === "string" && params.topic.trim()
+      ? (params.topic.trim() as KnowledgeEntry["topic"])
+      : "specialty_research";
+
+  const entry: KnowledgeEntry = {
+    id: crypto.randomUUID(),
+    topic,
+    specialty,
+    insight,
+    source: "memory_tool",
+    timestamp: Date.now(),
+  };
+
+  storeKnowledge(entry);
+  return { success: true, output: `Saved knowledge entry ${entry.id}.` };
+}
+
+function handleDelete(params: Record<string, unknown>): ToolResult {
+  const id = requireString(params, "id");
+  const deleted = deleteKnowledge(id);
+  if (!deleted) {
+    return { success: false, output: `Entry not found: ${id}`, error: "not_found" };
+  }
+  return { success: true, output: `Deleted entry ${id}.` };
+}
+
+function handleList(): ToolResult {
+  const entries = loadKnowledge();
+  if (entries.length === 0) {
+    return { success: true, output: "Knowledge base is empty." };
+  }
+
+  const summary = entries
+    .map(
+      (e) =>
+        `- ${e.id}: [${e.topic}/${e.specialty}] ${e.insight.slice(0, 120)}`,
+    )
+    .join("\n");
+
+  return {
+    success: true,
+    output: `${entries.length} entries:\n${summary}`,
+  };
+}
+
+export const memoryTool: Tool = {
+  name: "memory",
+  description:
+    "Search, save, delete, or list entries in the knowledge base. " +
+    "Use action=search with a query to find relevant past knowledge, " +
+    "action=save to add new knowledge, action=delete to remove an entry, " +
+    "or action=list to see all entries.",
+  parameters: [
+    { name: "action", type: "string", description: "One of: search, save, delete, list", required: true },
+    { name: "query", type: "string", description: "Search query (required for action=search)" },
+    { name: "content", type: "string", description: "Knowledge content to save (required for action=save)" },
+    { name: "specialty", type: "string", description: "Specialty tag for the entry (optional, default: general)" },
+    { name: "topic", type: "string", description: "Topic: feedback_analysis, specialty_research, or task_simulation (optional)" },
+    { name: "id", type: "string", description: "Entry ID (required for action=delete)" },
+    { name: "limit", type: "number", description: "Max results for search (default 5)" },
+  ],
+
+  async execute(params: Record<string, unknown>): Promise<ToolResult> {
+    const action = requireString(params, "action");
+
+    switch (action) {
+      case "search":
+        return handleSearch(params);
+      case "save":
+        return handleSave(params);
+      case "delete":
+        return handleDelete(params);
+      case "list":
+        return handleList();
+      default:
+        return {
+          success: false,
+          output: `Unknown action: ${action}. Use search, save, delete, or list.`,
+          error: "invalid_action",
+        };
+    }
+  },
+};

--- a/src/core/tools/npm-install.ts
+++ b/src/core/tools/npm-install.ts
@@ -1,0 +1,67 @@
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+import type { Tool, ToolResult } from "./types.js";
+
+const execAsync = promisify(exec);
+
+/** Packages matching this prefix install without user confirmation. */
+const TRUSTED_PREFIX = "betsy-";
+
+export const npmInstallTool: Tool = {
+  name: "npm_install",
+  description:
+    "Install an npm package. Packages prefixed with 'betsy-' install " +
+    "without confirmation; all others require explicit approval.",
+  parameters: [
+    {
+      name: "package_name",
+      type: "string",
+      description: "The npm package name to install (e.g. 'lodash' or 'betsy-utils')",
+      required: true,
+    },
+  ],
+  // Default to requiring confirmation; overridden at runtime for trusted packages.
+  requiresConfirmation: true,
+
+  async execute(params: Record<string, unknown>): Promise<ToolResult> {
+    const packageName = params.package_name;
+    if (typeof packageName !== "string" || !packageName.trim()) {
+      return {
+        success: false,
+        output: "Missing required parameter: package_name",
+        error: "missing_param",
+      };
+    }
+
+    const name = packageName.trim();
+
+    // Basic validation: reject shell meta-characters to prevent injection.
+    if (/[;&|`$(){}[\]<>!#]/.test(name)) {
+      return {
+        success: false,
+        output: `Invalid package name: ${name}`,
+        error: "invalid_name",
+      };
+    }
+
+    try {
+      const { stdout, stderr } = await execAsync(`npm install ${name}`, {
+        timeout: 120_000,
+      });
+      const output = [stdout, stderr].filter(Boolean).join("\n").trim();
+      return { success: true, output: output || `Installed ${name}.` };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return {
+        success: false,
+        output: `Failed to install ${name}: ${msg}`,
+        error: "install_failed",
+      };
+    }
+  },
+};
+
+/** Runtime helper: returns true when the package can be installed silently. */
+export function isTrustedPackage(packageName: string): boolean {
+  return packageName.trim().startsWith(TRUSTED_PREFIX);
+}

--- a/src/core/tools/scheduler.ts
+++ b/src/core/tools/scheduler.ts
@@ -1,0 +1,228 @@
+import type { Tool, ToolResult } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Minimal cron-expression parser (supports "m h dom mon dow" five-field format)
+// ---------------------------------------------------------------------------
+
+interface CronFields {
+  minute: Set<number>;
+  hour: Set<number>;
+  dayOfMonth: Set<number>;
+  month: Set<number>;
+  dayOfWeek: Set<number>;
+}
+
+function parseField(field: string, min: number, max: number): Set<number> {
+  const values = new Set<number>();
+
+  for (const part of field.split(",")) {
+    if (part === "*") {
+      for (let i = min; i <= max; i++) values.add(i);
+      continue;
+    }
+
+    const stepMatch = part.match(/^(\*|\d+-\d+)\/(\d+)$/);
+    if (stepMatch) {
+      let start = min;
+      let end = max;
+      if (stepMatch[1] !== "*") {
+        const [s, e] = stepMatch[1].split("-").map(Number);
+        start = s;
+        end = e;
+      }
+      const step = Number(stepMatch[2]);
+      for (let i = start; i <= end; i += step) values.add(i);
+      continue;
+    }
+
+    const rangeMatch = part.match(/^(\d+)-(\d+)$/);
+    if (rangeMatch) {
+      const start = Number(rangeMatch[1]);
+      const end = Number(rangeMatch[2]);
+      for (let i = start; i <= end; i++) values.add(i);
+      continue;
+    }
+
+    const num = Number(part);
+    if (!Number.isNaN(num) && num >= min && num <= max) {
+      values.add(num);
+    }
+  }
+
+  return values;
+}
+
+function parseCron(expression: string): CronFields {
+  const parts = expression.trim().split(/\s+/);
+  if (parts.length !== 5) {
+    throw new Error(
+      `Invalid cron expression "${expression}": expected 5 fields (minute hour dom month dow)`,
+    );
+  }
+  return {
+    minute: parseField(parts[0], 0, 59),
+    hour: parseField(parts[1], 0, 23),
+    dayOfMonth: parseField(parts[2], 1, 31),
+    month: parseField(parts[3], 1, 12),
+    dayOfWeek: parseField(parts[4], 0, 6),
+  };
+}
+
+function cronMatches(fields: CronFields, date: Date): boolean {
+  return (
+    fields.minute.has(date.getMinutes()) &&
+    fields.hour.has(date.getHours()) &&
+    fields.dayOfMonth.has(date.getDate()) &&
+    fields.month.has(date.getMonth() + 1) &&
+    fields.dayOfWeek.has(date.getDay())
+  );
+}
+
+// ---------------------------------------------------------------------------
+// In-memory task store
+// ---------------------------------------------------------------------------
+
+export interface ScheduledTask {
+  name: string;
+  cronExpression: string;
+  command: string;
+  fields: CronFields;
+  lastRun: number;
+}
+
+const tasks = new Map<string, ScheduledTask>();
+
+/** Interval handle for the scheduler tick loop. */
+let tickHandle: ReturnType<typeof setInterval> | null = null;
+/** Registered callback invoked when a task fires. */
+let onFire: ((task: ScheduledTask) => void) | null = null;
+
+/** Start the scheduler tick (checks once per minute). */
+function ensureTicking(): void {
+  if (tickHandle) return;
+  tickHandle = setInterval(() => {
+    const now = new Date();
+    for (const task of tasks.values()) {
+      if (cronMatches(task.fields, now) && now.getTime() - task.lastRun > 59_000) {
+        task.lastRun = now.getTime();
+        onFire?.(task);
+      }
+    }
+  }, 60_000);
+  // Allow the process to exit even if the interval is running.
+  if (tickHandle && typeof tickHandle === "object" && "unref" in tickHandle) {
+    tickHandle.unref();
+  }
+}
+
+/** Stop the scheduler tick loop. */
+export function stopScheduler(): void {
+  if (tickHandle) {
+    clearInterval(tickHandle);
+    tickHandle = null;
+  }
+}
+
+/** Register a callback for when a scheduled task fires. */
+export function onTaskFire(cb: (task: ScheduledTask) => void): void {
+  onFire = cb;
+}
+
+// ---------------------------------------------------------------------------
+// Tool actions
+// ---------------------------------------------------------------------------
+
+function handleAdd(params: Record<string, unknown>): ToolResult {
+  const name = params.name;
+  if (typeof name !== "string" || !name.trim()) {
+    return { success: false, output: "Missing required parameter: name", error: "missing_param" };
+  }
+  const cronExpression = params.cron_expression;
+  if (typeof cronExpression !== "string" || !cronExpression.trim()) {
+    return { success: false, output: "Missing required parameter: cron_expression", error: "missing_param" };
+  }
+  const command = params.command;
+  if (typeof command !== "string" || !command.trim()) {
+    return { success: false, output: "Missing required parameter: command", error: "missing_param" };
+  }
+
+  let fields: CronFields;
+  try {
+    fields = parseCron(cronExpression);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { success: false, output: msg, error: "invalid_cron" };
+  }
+
+  const task: ScheduledTask = {
+    name: name.trim(),
+    cronExpression: cronExpression.trim(),
+    command: command.trim(),
+    fields,
+    lastRun: 0,
+  };
+
+  tasks.set(task.name, task);
+  ensureTicking();
+
+  return { success: true, output: `Scheduled task "${task.name}" with cron "${task.cronExpression}".` };
+}
+
+function handleRemove(params: Record<string, unknown>): ToolResult {
+  const name = params.name;
+  if (typeof name !== "string" || !name.trim()) {
+    return { success: false, output: "Missing required parameter: name", error: "missing_param" };
+  }
+  const deleted = tasks.delete(name.trim());
+  if (!deleted) {
+    return { success: false, output: `No scheduled task named "${name.trim()}".`, error: "not_found" };
+  }
+  if (tasks.size === 0) stopScheduler();
+  return { success: true, output: `Removed scheduled task "${name.trim()}".` };
+}
+
+function handleList(): ToolResult {
+  if (tasks.size === 0) {
+    return { success: true, output: "No scheduled tasks." };
+  }
+  const lines = [...tasks.values()].map(
+    (t) => `- ${t.name}: "${t.cronExpression}" -> ${t.command}`,
+  );
+  return { success: true, output: `${tasks.size} scheduled task(s):\n${lines.join("\n")}` };
+}
+
+export const schedulerTool: Tool = {
+  name: "scheduler",
+  description:
+    "Manage scheduled tasks using cron expressions. " +
+    "action=add to create a task (requires name, cron_expression, command), " +
+    "action=remove to delete a task by name, action=list to show all tasks.",
+  parameters: [
+    { name: "action", type: "string", description: "One of: add, remove, list", required: true },
+    { name: "name", type: "string", description: "Task name (required for add/remove)" },
+    { name: "cron_expression", type: "string", description: "Five-field cron expression, e.g. '*/5 * * * *' (required for add)" },
+    { name: "command", type: "string", description: "Command to execute when the task fires (required for add)" },
+  ],
+
+  async execute(params: Record<string, unknown>): Promise<ToolResult> {
+    const action = params.action;
+    if (typeof action !== "string" || !action.trim()) {
+      return { success: false, output: "Missing required parameter: action", error: "missing_param" };
+    }
+
+    switch (action.trim()) {
+      case "add":
+        return handleAdd(params);
+      case "remove":
+        return handleRemove(params);
+      case "list":
+        return handleList();
+      default:
+        return {
+          success: false,
+          output: `Unknown action: ${action}. Use add, remove, or list.`,
+          error: "invalid_action",
+        };
+    }
+  },
+};

--- a/src/core/tools/self-config.ts
+++ b/src/core/tools/self-config.ts
@@ -1,0 +1,138 @@
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import type { Tool, ToolResult } from "./types.js";
+
+const CONFIG_DIR = path.join(os.homedir(), ".betsy");
+const CONFIG_PATH = path.join(CONFIG_DIR, "config.yaml");
+
+// ---------------------------------------------------------------------------
+// Minimal YAML helpers (no external dependency)
+//
+// The config file uses a flat key: value structure, which is simple enough to
+// parse and serialise without pulling in a full YAML library.
+// ---------------------------------------------------------------------------
+
+type ConfigMap = Record<string, string>;
+
+function parseYaml(text: string): ConfigMap {
+  const map: ConfigMap = {};
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const idx = trimmed.indexOf(":");
+    if (idx === -1) continue;
+    const key = trimmed.slice(0, idx).trim();
+    let value = trimmed.slice(idx + 1).trim();
+    // Strip surrounding quotes
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    map[key] = value;
+  }
+  return map;
+}
+
+function serializeYaml(map: ConfigMap): string {
+  return Object.entries(map)
+    .map(([k, v]) => {
+      // Quote values that contain special YAML characters
+      const needsQuoting = /[:#\[\]{},>|&!%@`]/.test(v) || v === "";
+      const quoted = needsQuoting ? `"${v.replace(/"/g, '\\"')}"` : v;
+      return `${k}: ${quoted}`;
+    })
+    .join("\n") + "\n";
+}
+
+function readConfig(): ConfigMap {
+  try {
+    return parseYaml(fs.readFileSync(CONFIG_PATH, "utf-8"));
+  } catch {
+    return {};
+  }
+}
+
+function writeConfig(map: ConfigMap): void {
+  fs.mkdirSync(CONFIG_DIR, { recursive: true });
+  fs.writeFileSync(CONFIG_PATH, serializeYaml(map));
+}
+
+// ---------------------------------------------------------------------------
+// Tool actions
+// ---------------------------------------------------------------------------
+
+function handleGet(params: Record<string, unknown>): ToolResult {
+  const key = params.key;
+  if (typeof key !== "string" || !key.trim()) {
+    return { success: false, output: "Missing required parameter: key", error: "missing_param" };
+  }
+  const config = readConfig();
+  const value = config[key.trim()];
+  if (value === undefined) {
+    return { success: true, output: `Key "${key.trim()}" is not set.` };
+  }
+  return { success: true, output: `${key.trim()}: ${value}` };
+}
+
+function handleSet(params: Record<string, unknown>): ToolResult {
+  const key = params.key;
+  if (typeof key !== "string" || !key.trim()) {
+    return { success: false, output: "Missing required parameter: key", error: "missing_param" };
+  }
+  const value = params.value;
+  if (value === undefined || value === null) {
+    return { success: false, output: "Missing required parameter: value", error: "missing_param" };
+  }
+  const config = readConfig();
+  config[key.trim()] = String(value);
+  writeConfig(config);
+  return { success: true, output: `Set ${key.trim()} = ${String(value)}` };
+}
+
+function handleList(): ToolResult {
+  const config = readConfig();
+  const keys = Object.keys(config);
+  if (keys.length === 0) {
+    return { success: true, output: "Config is empty." };
+  }
+  const lines = keys.map((k) => `- ${k}: ${config[k]}`);
+  return { success: true, output: `${keys.length} key(s):\n${lines.join("\n")}` };
+}
+
+export const selfConfigTool: Tool = {
+  name: "self_config",
+  description:
+    "Read or write Betsy's own configuration stored in ~/.betsy/config.yaml. " +
+    "action=get retrieves a single key, action=set writes a key-value pair, " +
+    "action=list shows all configuration entries.",
+  parameters: [
+    { name: "action", type: "string", description: "One of: get, set, list", required: true },
+    { name: "key", type: "string", description: "Config key (required for get/set)" },
+    { name: "value", type: "string", description: "Config value (required for set)" },
+  ],
+
+  async execute(params: Record<string, unknown>): Promise<ToolResult> {
+    const action = params.action;
+    if (typeof action !== "string" || !action.trim()) {
+      return { success: false, output: "Missing required parameter: action", error: "missing_param" };
+    }
+
+    switch (action.trim()) {
+      case "get":
+        return handleGet(params);
+      case "set":
+        return handleSet(params);
+      case "list":
+        return handleList();
+      default:
+        return {
+          success: false,
+          output: `Unknown action: ${action}. Use get, set, or list.`,
+          error: "invalid_action",
+        };
+    }
+  },
+};

--- a/src/core/tools/ssh.ts
+++ b/src/core/tools/ssh.ts
@@ -1,0 +1,102 @@
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+import type { Tool, ToolResult } from "./types.js";
+
+const execAsync = promisify(exec);
+
+/** Maximum time (ms) to wait for an SSH command to complete. */
+const SSH_TIMEOUT = 30_000;
+
+export const sshTool: Tool = {
+  name: "ssh",
+  description:
+    "Execute a command on a remote host over SSH. " +
+    "Requires host and command at minimum. Optionally provide username " +
+    "and key (path to private key). Always requires confirmation.",
+  parameters: [
+    { name: "host", type: "string", description: "Remote hostname or IP", required: true },
+    { name: "command", type: "string", description: "Command to run on the remote host", required: true },
+    { name: "username", type: "string", description: "SSH username (defaults to current user)" },
+    { name: "key", type: "string", description: "Path to SSH private key file" },
+    { name: "port", type: "number", description: "SSH port (default 22)" },
+  ],
+  requiresConfirmation: true,
+
+  async execute(params: Record<string, unknown>): Promise<ToolResult> {
+    const host = params.host;
+    if (typeof host !== "string" || !host.trim()) {
+      return { success: false, output: "Missing required parameter: host", error: "missing_param" };
+    }
+
+    const command = params.command;
+    if (typeof command !== "string" || !command.trim()) {
+      return { success: false, output: "Missing required parameter: command", error: "missing_param" };
+    }
+
+    // Validate inputs to prevent shell injection via the host/username/key fields.
+    const safePattern = /^[a-zA-Z0-9._@:\/~\-]+$/;
+
+    if (!safePattern.test(host.trim())) {
+      return { success: false, output: `Invalid host: ${host}`, error: "invalid_param" };
+    }
+
+    const username =
+      typeof params.username === "string" && params.username.trim()
+        ? params.username.trim()
+        : undefined;
+
+    if (username && !safePattern.test(username)) {
+      return { success: false, output: `Invalid username: ${username}`, error: "invalid_param" };
+    }
+
+    const keyPath =
+      typeof params.key === "string" && params.key.trim()
+        ? params.key.trim()
+        : undefined;
+
+    if (keyPath && !safePattern.test(keyPath)) {
+      return { success: false, output: `Invalid key path: ${keyPath}`, error: "invalid_param" };
+    }
+
+    const port =
+      typeof params.port === "number" && Number.isInteger(params.port)
+        ? params.port
+        : 22;
+
+    // Build SSH command
+    const args: string[] = ["ssh", "-o", "StrictHostKeyChecking=accept-new", "-o", "ConnectTimeout=10"];
+
+    if (keyPath) {
+      args.push("-i", keyPath);
+    }
+
+    if (port !== 22) {
+      args.push("-p", String(port));
+    }
+
+    const target = username ? `${username}@${host.trim()}` : host.trim();
+    args.push(target);
+
+    // The remote command is passed as a single string argument.
+    // We escape single quotes for shell safety.
+    const escapedCommand = command.replace(/'/g, "'\\''");
+    args.push(`'${escapedCommand}'`);
+
+    const sshCommand = args.join(" ");
+
+    try {
+      const { stdout, stderr } = await execAsync(sshCommand, {
+        timeout: SSH_TIMEOUT,
+      });
+      const output = [stdout, stderr].filter(Boolean).join("\n").trim();
+      return { success: true, output: output || "(no output)" };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return {
+        success: false,
+        output: `SSH command failed: ${msg}`,
+        error: "ssh_failed",
+      };
+    }
+  },
+};

--- a/src/core/tools/types.ts
+++ b/src/core/tools/types.ts
@@ -1,0 +1,20 @@
+export interface ToolParam {
+  name: string;
+  type: string;
+  description: string;
+  required?: boolean;
+}
+
+export interface ToolResult {
+  success: boolean;
+  output: string;
+  error?: string;
+}
+
+export interface Tool {
+  name: string;
+  description: string;
+  parameters: ToolParam[];
+  requiresConfirmation?: boolean;
+  execute(params: Record<string, unknown>): Promise<ToolResult>;
+}


### PR DESCRIPTION
## Summary
- Adds five new tools under `src/core/tools/` as part of Unit 8 of the agent restructure
- **memory**: search/save/delete/list knowledge base entries, wrapping existing `memory/knowledge` and `memory/search` modules
- **npm_install**: install npm packages with shell injection protection; `betsy-*` packages skip confirmation, others require it
- **scheduler**: in-memory cron-like task scheduling with a minimal five-field cron parser and 60s tick loop (no external deps)
- **self_config**: read/write `~/.betsy/config.yaml` with a minimal flat-YAML parser (no external yaml dependency)
- **ssh**: execute remote commands via `child_process` ssh with input validation and `requiresConfirmation=true`
- Adds `src/core/tools/types.ts` with shared `Tool`, `ToolParam`, and `ToolResult` interfaces

## Test plan
- [x] TypeScript compiles cleanly (`npx tsc --noEmit` passes with zero errors)
- [ ] Manual verification of memory tool with existing knowledge base
- [ ] Manual verification of scheduler add/remove/list lifecycle
- [ ] Manual verification of self-config get/set/list against `~/.betsy/config.yaml`
- [ ] SSH and npm-install require external services; skip automated e2e

🤖 Generated with [Claude Code](https://claude.com/claude-code)