### PR TITLE
fix: handle BigInt serialization on Windows

### DIFF
--- a/src/tools/agentcash.ts
+++ b/src/tools/agentcash.ts
@@ -4,6 +4,15 @@ import type { Tool, ToolResult } from "./types.js";
 
 const execFileAsync = promisify(execFile);
 
+function safeStringify(data: unknown): string {
+  return JSON.stringify(data, (key, value) => {
+    if (typeof value === "bigint") {
+      return value.toString();
+    }
+    return value;
+  });
+}
+
 const FETCH_TIMEOUT = 60_000;
 const BALANCE_TIMEOUT = 15_000;
 
@@ -95,7 +104,7 @@ export const agentcashFetch: Tool = {
 
     try {
       const result = await runAgentCash<unknown>(args, FETCH_TIMEOUT);
-      return { success: true, data: JSON.stringify(result, null, 2) };
+      return { success: true, data: safeStringify(result) };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       return { success: false, data: msg };
@@ -129,7 +138,7 @@ export const agentcashBalance: Tool = {
       );
       return {
         success: true,
-        data: JSON.stringify({
+        data: safeStringify({
           address: result.address,
           balanceUSDC: result.balance,
           network: result.network,

--- a/src/tools/marketplace.ts
+++ b/src/tools/marketplace.ts
@@ -1,6 +1,15 @@
 import type { Tool } from "./types.js";
 import * as cli from "../moltlaunch/cli.js";
 
+function safeStringify(data: unknown): string {
+  return JSON.stringify(data, (key, value) => {
+    if (typeof value === "bigint") {
+      return value.toString();
+    }
+    return value;
+  });
+}
+
 function requireString(input: Record<string, unknown>, key: string): string {
   const val = input[key];
   if (typeof val !== "string" || !val) throw new Error(`Missing required field: ${key}`);
@@ -22,7 +31,7 @@ export const readTask: Tool = {
   async execute(input) {
     const taskId = requireString(input, "task_id");
     const task = await cli.getTask(taskId);
-    return { success: true, data: JSON.stringify(task) };
+    return { success: true, data: safeStringify(task) };
   },
 };
 
@@ -121,7 +130,7 @@ export const listBounties: Tool = {
   },
   async execute() {
     const bounties = await cli.getBounties();
-    return { success: true, data: JSON.stringify(bounties) };
+    return { success: true, data: safeStringify(bounties) };
   },
 };
 


### PR DESCRIPTION
## Summary
- Add `safeStringify` utility function to handle BigInt values in JSON.stringify
- Apply fix to `marketplace.ts` and `agentcash.ts`
- Fixes `Do not know how to serialize a BigInt` error on Windows when running `mltl register` or `mltl profile` commands

## Changes
- Added `safeStringify()` function that converts BigInt to string using `toString()`
- Updated 3 JSON.stringify calls to use the new utility

## Testing
The fix follows the suggestion in issue #29:
```javascript
JSON.stringify(data, (_, v) => typeof v === 'bigint' ? v.toString() : v)
```

Closes #29