### PR TITLE
feat: add secure filesystem tools (read_file, write_file, list_directory)

### DIFF
--- a/src/tools/filesystem.ts
+++ b/src/tools/filesystem.ts
@@ -1,0 +1,265 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { Tool, ToolResult } from "./types.js";
+
+const MAX_FILE_SIZE = 1_048_576; // 1 MB
+const MAX_ENTRIES = 500;
+const MAX_DEPTH = 3;
+
+/**
+ * Returns the current allowlist of base directories.
+ * Computed per-call so that changes to cwd are respected.
+ */
+function getAllowedBases(): string[] {
+  return [fs.realpathSync(os.tmpdir()), fs.realpathSync(process.cwd())];
+}
+
+/**
+ * Resolves a path and follows symlinks, then checks against the allowlist.
+ * Uses fs.realpathSync to prevent symlink escapes.
+ */
+function resolveAndCheck(targetPath: string): { allowed: true; resolved: string } | { allowed: false; resolved: string } {
+  const resolved = path.resolve(targetPath);
+
+  // Use realpath to follow symlinks and prevent escapes.
+  // Walk up to find the nearest existing ancestor for new paths.
+  let realResolved: string;
+  try {
+    realResolved = fs.realpathSync(resolved);
+  } catch {
+    // Path doesn't exist yet — find the nearest existing ancestor
+    let current = resolved;
+    let tail: string[] = [];
+    while (true) {
+      const parent = path.dirname(current);
+      if (parent === current) {
+        // Reached filesystem root without finding an existing dir
+        return { allowed: false, resolved };
+      }
+      tail.unshift(path.basename(current));
+      current = parent;
+      try {
+        const realAncestor = fs.realpathSync(current);
+        realResolved = path.join(realAncestor, ...tail);
+        break;
+      } catch {
+        continue;
+      }
+    }
+  }
+
+  const bases = getAllowedBases();
+  const allowed = bases.some(
+    (base) =>
+      realResolved.startsWith(base + path.sep) || realResolved === base,
+  );
+
+  return { allowed, resolved: realResolved };
+}
+
+export const readFile: Tool = {
+  definition: {
+    name: "read_file",
+    description:
+      "Read a file and return its contents. Returns UTF-8 text by default, or base64 for binary files.",
+    input_schema: {
+      type: "object" as const,
+      properties: {
+        path: { type: "string", description: "File path to read" },
+        encoding: {
+          type: "string",
+          enum: ["utf8", "base64"],
+          description: "File encoding (default: utf8)",
+        },
+      },
+      required: ["path"],
+    },
+  },
+  async execute(input): Promise<ToolResult> {
+    const filePath = input.path as string;
+    const encoding = (input.encoding as string | undefined) ?? "utf8";
+
+    const check = resolveAndCheck(filePath);
+    if (!check.allowed) {
+      return { success: false, data: `Access denied: ${check.resolved}` };
+    }
+
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(check.resolved);
+    } catch {
+      return { success: false, data: `File not found: ${check.resolved}` };
+    }
+
+    if (stat.size > MAX_FILE_SIZE) {
+      return {
+        success: false,
+        data: `File too large: ${stat.size} bytes (max ${MAX_FILE_SIZE})`,
+      };
+    }
+
+    const content = fs.readFileSync(check.resolved, encoding as BufferEncoding);
+    return { success: true, data: content };
+  },
+};
+
+export const writeFile: Tool = {
+  definition: {
+    name: "write_file",
+    description:
+      "Write content to a file, creating parent directories as needed.",
+    input_schema: {
+      type: "object" as const,
+      properties: {
+        path: { type: "string", description: "File path to write" },
+        content: { type: "string", description: "Content to write" },
+        mode: {
+          type: "string",
+          enum: ["overwrite", "append"],
+          description: "Write mode (default: overwrite)",
+        },
+      },
+      required: ["path", "content"],
+    },
+  },
+  async execute(input): Promise<ToolResult> {
+    const filePath = input.path as string;
+    const content = input.content as string;
+    const mode = (input.mode as string | undefined) ?? "overwrite";
+
+    const check = resolveAndCheck(filePath);
+    if (!check.allowed) {
+      return { success: false, data: `Access denied: ${check.resolved}` };
+    }
+
+    fs.mkdirSync(path.dirname(check.resolved), { recursive: true });
+    fs.writeFileSync(check.resolved, content, {
+      flag: mode === "append" ? "a" : "w",
+    });
+
+    return {
+      success: true,
+      data: `Written ${content.length} bytes to ${check.resolved}`,
+    };
+  },
+};
+
+interface EntryInfo {
+  name: string;
+  type: "file" | "dir";
+  size: number;
+  modified: string;
+}
+
+function listDir(
+  dirPath: string,
+  depth: number,
+  maxDepth: number,
+  suffix: string | undefined,
+  entries: EntryInfo[],
+  allowedBases: string[],
+): void {
+  if (depth > maxDepth || entries.length >= MAX_ENTRIES) return;
+
+  const items = fs.readdirSync(dirPath, { withFileTypes: true });
+  for (const item of items) {
+    if (entries.length >= MAX_ENTRIES) break;
+
+    const fullPath = path.join(dirPath, item.name);
+
+    // Resolve symlinks and re-check allowlist on every entry during recursion
+    let realPath: string;
+    try {
+      realPath = fs.realpathSync(fullPath);
+    } catch {
+      continue; // broken symlink — skip
+    }
+
+    const inBounds = allowedBases.some(
+      (base) => realPath.startsWith(base + path.sep) || realPath === base,
+    );
+    if (!inBounds) continue;
+
+    const stat = fs.statSync(realPath);
+    const isDir = stat.isDirectory();
+
+    if (!suffix || isDir || item.name.endsWith(suffix)) {
+      entries.push({
+        name: fullPath,
+        type: isDir ? "dir" : "file",
+        size: isDir ? 0 : stat.size,
+        modified: stat.mtime.toISOString(),
+      });
+    }
+
+    if (isDir && depth < maxDepth) {
+      listDir(realPath, depth + 1, maxDepth, suffix, entries, allowedBases);
+    }
+  }
+}
+
+export const listDirectory: Tool = {
+  definition: {
+    name: "list_directory",
+    description:
+      "List files and directories. Returns a JSON array with name, type, size, and modified date.",
+    input_schema: {
+      type: "object" as const,
+      properties: {
+        path: { type: "string", description: "Directory path to list" },
+        recursive: {
+          type: "boolean",
+          description: "Recurse into subdirectories (max depth 3)",
+        },
+        pattern: {
+          type: "string",
+          description:
+            'Filter by file extension, e.g. "*.ts" matches files ending in .ts',
+        },
+      },
+      required: ["path"],
+    },
+  },
+  async execute(input): Promise<ToolResult> {
+    const dirPath = input.path as string;
+    const recursive = (input.recursive as boolean | undefined) ?? false;
+    const pattern = input.pattern as string | undefined;
+
+    const check = resolveAndCheck(dirPath);
+    if (!check.allowed) {
+      return { success: false, data: `Access denied: ${check.resolved}` };
+    }
+
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(check.resolved);
+    } catch {
+      return { success: false, data: `Not a directory: ${check.resolved}` };
+    }
+    if (!stat.isDirectory()) {
+      return { success: false, data: `Not a directory: ${check.resolved}` };
+    }
+
+    // Extract suffix from "*.ext" pattern — only support extension filters
+    let suffix: string | undefined;
+    if (pattern) {
+      const match = pattern.match(/^\*(\.\w+)$/);
+      if (match) {
+        suffix = match[1];
+      } else {
+        return {
+          success: false,
+          data: `Invalid pattern "${pattern}": use "*.ext" format (e.g. "*.ts")`,
+        };
+      }
+    }
+
+    const maxDepth = recursive ? MAX_DEPTH : 1;
+    const entries: EntryInfo[] = [];
+    const allowedBases = getAllowedBases();
+    listDir(check.resolved, 1, maxDepth, suffix, entries, allowedBases);
+
+    return { success: true, data: JSON.stringify(entries, null, 2) };
+  },
+};

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -17,6 +17,7 @@ import {
   logActivity,
 } from "./utility.js";
 import { agentcashFetch, agentcashBalance } from "./agentcash.js";
+import { readFile, writeFile, listDirectory } from "./filesystem.js";
 
 const BASE_TOOLS: Tool[] = [
   readTask,
@@ -32,6 +33,8 @@ const BASE_TOOLS: Tool[] = [
   logActivity,
 ];
 
+const FILESYSTEM_TOOLS: Tool[] = [readFile, writeFile, listDirectory];
+
 const AGENTCASH_TOOLS: Tool[] = [
   agentcashFetch,
   agentcashBalance,
@@ -44,8 +47,8 @@ let cachedToolMap: Map<string, Tool> | null = null;
 function buildToolMap(config: CashClawConfig): Map<string, Tool> {
   if (cachedConfig === config && cachedToolMap) return cachedToolMap;
   const tools = config.agentCashEnabled
-    ? [...BASE_TOOLS, ...AGENTCASH_TOOLS]
-    : BASE_TOOLS;
+    ? [...BASE_TOOLS, ...FILESYSTEM_TOOLS, ...AGENTCASH_TOOLS]
+    : [...BASE_TOOLS, ...FILESYSTEM_TOOLS];
   cachedToolMap = new Map(tools.map((t) => [t.definition.name, t]));
   cachedConfig = config;
   return cachedToolMap;

--- a/test/filesystem.test.ts
+++ b/test/filesystem.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { readFile, writeFile, listDirectory } from "../src/tools/filesystem.js";
+import type { ToolContext } from "../src/tools/types.js";
+
+const ctx = {} as ToolContext;
+let tmpDir: string;
+
+beforeAll(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "cashclaw-test-"));
+});
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("readFile", () => {
+  it("reads a file inside cwd", async () => {
+    const result = await readFile.execute({ path: "package.json" }, ctx);
+    expect(result.success).toBe(true);
+    expect(result.data).toContain("cashclaw-agent");
+  });
+
+  it("reads a file in tmpdir", async () => {
+    const filePath = path.join(tmpDir, "hello.txt");
+    fs.writeFileSync(filePath, "hello world");
+    const result = await readFile.execute({ path: filePath }, ctx);
+    expect(result.success).toBe(true);
+    expect(result.data).toBe("hello world");
+  });
+
+  it("denies access to paths outside the allowlist", async () => {
+    const result = await readFile.execute({ path: "/etc/passwd" }, ctx);
+    expect(result.success).toBe(false);
+    expect(result.data).toContain("Access denied");
+  });
+
+  it("returns error for non-existent file", async () => {
+    const result = await readFile.execute({ path: path.join(tmpDir, "nope.txt") }, ctx);
+    expect(result.success).toBe(false);
+    expect(result.data).toContain("File not found");
+  });
+
+  it("blocks symlink escape", async () => {
+    const linkPath = path.join(tmpDir, "sneaky-link");
+    try {
+      fs.symlinkSync("/etc/passwd", linkPath);
+    } catch {
+      // symlink creation may fail on some systems — skip
+      return;
+    }
+    const result = await readFile.execute({ path: linkPath }, ctx);
+    expect(result.success).toBe(false);
+    expect(result.data).toContain("Access denied");
+  });
+});
+
+describe("writeFile", () => {
+  it("writes a new file in tmpdir", async () => {
+    const filePath = path.join(tmpDir, "output.txt");
+    const result = await writeFile.execute({ path: filePath, content: "test content" }, ctx);
+    expect(result.success).toBe(true);
+    expect(fs.readFileSync(filePath, "utf8")).toBe("test content");
+  });
+
+  it("appends to an existing file", async () => {
+    const filePath = path.join(tmpDir, "append.txt");
+    fs.writeFileSync(filePath, "first ");
+    const result = await writeFile.execute(
+      { path: filePath, content: "second", mode: "append" },
+      ctx,
+    );
+    expect(result.success).toBe(true);
+    expect(fs.readFileSync(filePath, "utf8")).toBe("first second");
+  });
+
+  it("creates parent directories", async () => {
+    const filePath = path.join(tmpDir, "sub", "dir", "deep.txt");
+    const result = await writeFile.execute({ path: filePath, content: "deep" }, ctx);
+    expect(result.success).toBe(true);
+    expect(fs.existsSync(filePath)).toBe(true);
+  });
+
+  it("denies writing outside the allowlist", async () => {
+    const result = await writeFile.execute({ path: "/tmp/../etc/evil.txt", content: "bad" }, ctx);
+    expect(result.success).toBe(false);
+    expect(result.data).toContain("Access denied");
+  });
+});
+
+describe("listDirectory", () => {
+  it("lists a directory inside cwd", async () => {
+    const result = await listDirectory.execute({ path: "." }, ctx);
+    expect(result.success).toBe(true);
+    const entries = JSON.parse(result.data);
+    const names = entries.map((e: { name: string }) => path.basename(e.name));
+    expect(names).toContain("package.json");
+  });
+
+  it("supports recursive listing", async () => {
+    // Create a nested structure in tmpdir
+    const nested = path.join(tmpDir, "a", "b");
+    fs.mkdirSync(nested, { recursive: true });
+    fs.writeFileSync(path.join(nested, "deep.ts"), "x");
+
+    const result = await listDirectory.execute(
+      { path: tmpDir, recursive: true, pattern: "*.ts" },
+      ctx,
+    );
+    expect(result.success).toBe(true);
+    const entries = JSON.parse(result.data);
+    const names = entries.map((e: { name: string }) => path.basename(e.name));
+    expect(names).toContain("deep.ts");
+  });
+
+  it("rejects invalid glob patterns", async () => {
+    const result = await listDirectory.execute(
+      { path: tmpDir, pattern: "foo*" },
+      ctx,
+    );
+    expect(result.success).toBe(false);
+    expect(result.data).toContain("Invalid pattern");
+  });
+
+  it("denies listing outside the allowlist", async () => {
+    const result = await listDirectory.execute({ path: "/etc" }, ctx);
+    expect(result.success).toBe(false);
+    expect(result.data).toContain("Access denied");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `read_file`, `write_file`, and `list_directory` tools with path sandboxing to `cwd` and `os.tmpdir()`
- Fixes symlink escape vulnerability from #33 using `fs.realpathSync` on all path checks, including during recursive traversal
- Validates glob patterns strictly (`*.ext` only) and rejects malformed patterns with clear errors
- Resolves `cwd` dynamically instead of caching at module load
- 13 automated tests covering reads, writes, recursion, access denial, and symlink escape

## Test plan
- [x] `npm run typecheck` — passes
- [x] `npm test` — all 20 tests pass (7 existing + 13 new)
- [ ] Manual: read a file in cwd, verify contents returned
- [ ] Manual: write a file to os.tmpdir(), verify it exists
- [ ] Manual: list a directory with recursive: true and pattern: "*.ts"
- [ ] Manual: attempt to read /etc/passwd — verify "Access denied" error