### PR TITLE
fix: include frontend assets in npm package and add proxy support

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,4 @@
-assets/
+/assets/
 src/
 test/
 *.config.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
-  "name": "cashclaw",
+  "name": "cashclaw-agent",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "cashclaw",
+      "name": "cashclaw-agent",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "minisearch": "^7.2.0",
+        "undici": "^8.0.2",
         "viem": "^2.23.0",
         "ws": "^8.19.0"
       },
@@ -3271,6 +3272,15 @@
       "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.0.2.tgz",
+      "integrity": "sha512-B9MeU5wuFhkFAuNeA19K2GDFcQXZxq33fL0nRy2Aq30wdufZbyyvxW3/ChaeipXVfy/wUweZyzovQGk39+9k2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
     },
     "node_modules/undici-types": {
       "version": "6.21.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "minisearch": "^7.2.0",
+    "undici": "^8.0.2",
     "viem": "^2.23.0",
     "ws": "^8.19.0"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,12 @@
 import { startAgent } from "./agent.js";
 
+// Respect HTTPS_PROXY / ALL_PROXY for all fetch() calls (same as Claude Code)
+const _proxyUrl = process.env.HTTPS_PROXY || process.env.ALL_PROXY;
+if (_proxyUrl) {
+  const { ProxyAgent, setGlobalDispatcher } = await import("undici");
+  setGlobalDispatcher(new ProxyAgent(_proxyUrl));
+}
+
 async function main() {
   console.log("Starting CashClaw...");
 

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   outDir: "dist",
   clean: true,
   splitting: false,
+  external: ["undici"],
   sourcemap: true,
   dts: false,
   banner: { js: "#!/usr/bin/env node" },


### PR DESCRIPTION
## Summary

- **Blank dashboard on install**: `.npmignore` had `assets/` which excluded `dist/ui/assets/` (the Vite-built JS/CSS bundles) from the npm package. Dashboard loads `index.html` but scripts 404 → blank page. Fixed by changing to `/assets/` to only match the root-level README images directory.

- **LLM API fails behind proxy**: Node.js `fetch()` does not respect `ALL_PROXY`/`HTTPS_PROXY` environment variables natively. Users in regions requiring a proxy (e.g. Russia) get 403 from Anthropic/OpenAI. Added `undici` with `setGlobalDispatcher(new ProxyAgent(...))` at startup so all outgoing fetch calls automatically route through the configured proxy — same pattern Claude Code uses.

## Test plan

- [ ] `npm pack --dry-run` shows `dist/ui/assets/index-*.js` and `dist/ui/assets/index-*.css` in the package
- [ ] `npm install -g` on a clean machine → dashboard loads with working UI
- [ ] With `ALL_PROXY` set, LLM test connection in setup wizard succeeds
- [ ] Without `ALL_PROXY`, behavior is unchanged (no proxy used)

🤖 Generated with [Claude Code](https://claude.com/claude-code)