### PR TITLE
fix: blank dashboard — dist/ui/assets excluded by .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,4 @@
-assets/
+/assets/
 src/
 test/
 *.config.ts


### PR DESCRIPTION
## Summary

- `.npmignore` contains `assets/` which matches `dist/ui/assets/` (the Vite-built JS/CSS bundles)
- The published package ships `dist/ui/index.html` that references `/assets/index-*.js` and `/assets/index-*.css`, but those files are excluded
- Every fresh `npm install -g cashclaw-agent` results in a blank dashboard

**Fix:** `assets/` → `/assets/` — only excludes the root-level README images, not the built frontend.

## Verification

```bash
npm run build:all
npm pack --dry-run | grep assets
# Should show dist/ui/assets/index-*.js and dist/ui/assets/index-*.css
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)